### PR TITLE
Remove duplicate resource scanners from stock Surface Scanning Module

### DIFF
--- a/GameData/Workshop/MM_Workshop.cfg
+++ b/GameData/Workshop/MM_Workshop.cfg
@@ -364,36 +364,6 @@
 	}
 }
 
-@PART[SurfaceScanner]:FOR[Workshop]
-{
-	MODULE
-	{
-		name = ModuleResourceScanner
-		ScannerType = 0
-		ResourceName = Dirt
-		MaxAbundanceAltitude = 1000
-		RequiresUnlock = false
-	}
-
-	MODULE
-	{
-		name = ModuleResourceScanner
-		ScannerType = 0
-		ResourceName = ExoticMinerals
-		MaxAbundanceAltitude = 1000
-		RequiresUnlock = false
-	}
-
-	MODULE
-	{
-		name = ModuleResourceScanner
-		ScannerType = 0
-		ResourceName = RareMetals
-		MaxAbundanceAltitude = 1000
-		RequiresUnlock = false
-	}
-}
-
 //InventorypreferenceoptiontopartswithKISinventories
 @PART[*]:HAS[@MODULE[ModuleKISInventory]]:FINAL
 {


### PR DESCRIPTION
OSE Workshop patches the stock surface scanner to show concentrations of Dirt, ExoticMinerals, and RareMetals, because the workshop parts use those resources.  But recent versions of the Community Resource Pack already patch the scanner to show *all* the CRP resources, so the Workshop patch is redundant, and actually causes those three resources to appear twice in the scanner's UI.

This is a fix for obivandamme/Workshop#41.